### PR TITLE
Allow unused locals in tests

### DIFF
--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -9,6 +9,7 @@
         "alwaysStrict": true,
         "inlineSourceMap": true,
         "strictNullChecks": true,
+        "noUnusedLocals": false,
         "lib": [
             "es6", "es2015.collection"
         ],


### PR DESCRIPTION
Running tests results a a number of errors. This allows the unused local variables in the test tsconfig.

```
$ npm test
...
test/primitives.ts:37:11 - error TS6133: 'n2' is declared but its value is never read.

37       let n2: number = m;
             ~~
```