### PR TITLE
Update packages with security notices

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,12 +35,12 @@
   },
   "homepage": "https://github.com/jvilk/MakeTypes#readme",
   "devDependencies": {
-    "@types/mocha": "^2.2.34",
+    "@types/mocha": "^5.2.4",
     "@types/node": "0.0.2",
     "@types/yargs": "^6.3.3",
-    "coveralls": "^2.11.15",
+    "coveralls": "^3.0.2",
     "istanbul": "^1.0.0-alpha",
-    "mocha": "^3.2.0",
+    "mocha": "^5.2.0",
     "npm-run-all": "^3.1.2",
     "typescript": "^2.1.4"
   },

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -9,6 +9,7 @@
         "alwaysStrict": true,
         "inlineSourceMap": true,
         "strictNullChecks": true,
+        "noUnusedLocals": false,
         "lib": [
             "es6", "es2015.collection"
         ],


### PR DESCRIPTION
Minimally depends on #8 

**Before**

```
$ npm audit
found 7 vulnerabilities (1 low, 5 moderate, 1 critical) in 550 scanned packages
  7 vulnerabilities require semver-major dependency updates.
```


**After**

```
$ npm audit
found 0 vulnerabilities
 in 525 scanned packages
```