### PR TITLE
Accept multiple files as sample input

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2,10 +2,11 @@
 import * as yargs from 'yargs';
 import * as fs from 'fs';
 import * as path from 'path';
+import * as glob from 'glob';
 
-import {StreamWriter, NopWriter, Emitter} from './lib/index';
+import { StreamWriter, NopWriter, Emitter } from './lib/index';
 
-const argv = yargs.usage('Usage: $0 [options] inputFile rootName')
+const argv = yargs.usage('Usage: $0 [options] inputFile [...] rootName')
   .alias('i', 'interface-file')
   .string('i')
   .describe('i', 'Specify output file for interfaces')
@@ -29,12 +30,23 @@ if (argv.i) {
 if (argv.p) {
   proxyWriter = new StreamWriter(fs.createWriteStream(argv.p));
 }
-if (argv._.length !== 2) {
-  console.error(`Please supply an input file with samples in a JSON array, and a symbol to use for the root interface / proxy.`);
+
+if (argv._.length < 2) {
+  console.error(`Please supply one input file with samples in a JSON array or multiple files, and a symbol to use for the root interface / proxy.`);
   yargs.showHelp();
   process.exit(1);
 }
 
-const samples = JSON.parse(fs.readFileSync(argv._[0]).toString());
+const samplesArray = new Array<any>();
+
+for (const sampleParam of argv._.slice(0, -1)) {
+  for (const samplePath of glob.sync(sampleParam)) {
+    samplesArray.push(JSON.parse(fs.readFileSync(samplePath).toString()));
+  }
+}
+
+const samples = samplesArray.length === 1 ? samplesArray[0] : samplesArray;
+const rootName = argv._.slice(-1)[0];
+
 const e = new Emitter(interfaceWriter, proxyWriter);
-e.emit(samples, argv._[1]);
+e.emit(samples, rootName);

--- a/index.ts
+++ b/index.ts
@@ -2,9 +2,8 @@
 import * as yargs from 'yargs';
 import * as fs from 'fs';
 import * as path from 'path';
-import * as glob from 'glob';
 
-import { StreamWriter, NopWriter, Emitter } from './lib/index';
+import {StreamWriter, NopWriter, Emitter} from './lib/index';
 
 const argv = yargs.usage('Usage: $0 [options] inputFile [...] rootName')
   .alias('i', 'interface-file')
@@ -39,10 +38,8 @@ if (argv._.length < 2) {
 
 const samplesArray = new Array<any>();
 
-for (const sampleParam of argv._.slice(0, -1)) {
-  for (const samplePath of glob.sync(sampleParam)) {
-    samplesArray.push(JSON.parse(fs.readFileSync(samplePath).toString()));
-  }
+for (const samplePath of argv._.slice(0, -1)) {
+  samplesArray.push(JSON.parse(fs.readFileSync(samplePath).toString()));
 }
 
 const samples = samplesArray.length === 1 ? samplesArray[0] : samplesArray;

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   },
   "homepage": "https://github.com/jvilk/MakeTypes#readme",
   "devDependencies": {
-    "@types/glob": "^5.0.35",
     "@types/mocha": "^5.2.4",
     "@types/node": "0.0.2",
     "@types/yargs": "^6.3.3",
@@ -46,7 +45,6 @@
     "typescript": "^2.1.4"
   },
   "dependencies": {
-    "glob": "^7.1.3",
     "yargs": "^6.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "homepage": "https://github.com/jvilk/MakeTypes#readme",
   "devDependencies": {
+    "@types/glob": "^5.0.35",
     "@types/mocha": "^5.2.4",
     "@types/node": "0.0.2",
     "@types/yargs": "^6.3.3",
@@ -45,6 +46,7 @@
     "typescript": "^2.1.4"
   },
   "dependencies": {
+    "glob": "^7.1.3",
     "yargs": "^6.5.0"
   }
 }


### PR DESCRIPTION
Implementation for https://github.com/jvilk/MakeTypes/issues/10

This code allows multiple input, making the following input to work:
```bash
# Original functionality still working as before, accepting a json array or object
make_types [optons] input.json rootName

# Multiple explicit json objects
make_types foo1.json foo2.json bar.json rootName

# Multiple wildcard json objects
make_types foo*.json rootName

# Multiple wildcard and explicit json objects
make_types foo*.json bar.json rootName
```

Let me know if it works, sounds good, if you want to have something changed or added.