### PR TITLE
Added Emitter.emitShape API to enable the shape to be customised

### DIFF
--- a/lib/emit.ts
+++ b/lib/emit.ts
@@ -75,6 +75,9 @@ export default class Emitter {
   }
   public emit(root: any, rootName: string): void {
     let rootShape = d2s(this, root);
+    this.emitShape(rootShape, rootName)
+  }
+  public emitShape(rootShape: Shape, rootName: string): void {
     if (rootShape.type === BaseShape.COLLECTION) {
       rootShape = rootShape.baseShape;
     }


### PR DESCRIPTION
This adds an API so that the Shape can generated by the caller using `d2s` and then  customised prior to being emitted. For example, one can mark all fields as nullable without having to have a nullable example for each field in the dataset.