### PR TITLE
Several CLI improvements

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -5,19 +5,24 @@ import * as path from 'path';
 
 import {StreamWriter, NopWriter, Emitter} from './lib/index';
 
-const argv = yargs.usage('Usage: $0 [options] inputFile rootName')
+const argv = yargs.usage('Usage: $0 [options] inputFile [...] rootName')
   .alias('i', 'interface-file')
   .string('i')
-  .describe('i', 'Specify output file for interfaces')
+  .describe('i', 'Output file for interfaces')
   .alias('p', 'proxy-file')
   .string('p')
-  .describe('p', 'Specity output file for TypeScript proxy classes')
+  .describe('p', 'Output file for TypeScript proxy classes')
   .help('h')
   .alias('h', 'help')
   .argv;
 
 let interfaceWriter = new NopWriter();
 let proxyWriter = interfaceWriter;
+if (!argv.i && !argv.p) {
+  console.error('Please specify at least one of -i or -p to indicate desired output.');
+  yargs.showHelp();
+  process.exit(1);
+}
 if (argv.i && argv.p && path.resolve(argv.i) === path.resolve(argv.p)) {
   console.error(`Interfaces and proxies cannot be written to same file.`);
   yargs.showHelp();
@@ -29,12 +34,22 @@ if (argv.i) {
 if (argv.p) {
   proxyWriter = new StreamWriter(fs.createWriteStream(argv.p));
 }
-if (argv._.length !== 2) {
+if (argv._.length < 2) {
   console.error(`Please supply an input file with samples in a JSON array, and a symbol to use for the root interface / proxy.`);
   yargs.showHelp();
   process.exit(1);
 }
 
-const samples = JSON.parse(fs.readFileSync(argv._[0]).toString());
+const samples: any[] = [];
+for (const i of argv._.slice(0, -1)) {
+  const thisSample = JSON.parse(fs.readFileSync(i).toString());
+  if (Array.isArray(thisSample)) {
+    for (let j = 0; j < thisSample.length; j++) {
+      samples.push(thisSample[j]);
+    }
+  } else {
+    samples.push(thisSample);
+  }
+}
 const e = new Emitter(interfaceWriter, proxyWriter);
-e.emit(samples, argv._[1]);
+e.emit(samples, argv._[argv.length - 1]);


### PR DESCRIPTION
This PR is a bit of a grab bag: I don't know if you'll want all of these changes as is or not.

Part of this is similar to #11 (which I hadn't seen before I put this together); one difference is that this accepts passing a single file containing JSON sample object or multiple files containing JSON arrays of sample objects, while #11 assumes that a single parameter means a JSON array of sample objects and multiple parameters mean multiple files containing JSON sample objects.

Specific changes:

Shorten the help text; previously, yargs wasn't leaving a space between a parameter's help text and its type (`classes[string]`).

Fix a misspelling in help text.

Show a warning if neither -i nor -p is specified, to make the command a bit less confusing for those who don't read the help.

Allow providing multiple filenames as input.  (See #10.)

Allow input filenames to consist of a single JSON sample object as well as an array of JSON sample objects.