### PR TITLE
Reads from stdin

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 
 import { StreamWriter, NopWriter, Emitter } from './lib/index';
 
-const argv = yargs.usage('Usage: $0 [options] inputFile rootName\nFrom stdin, outputs interface by default.')
+const argv = yargs.usage('Usage: $0 [options] inputFile rootName\nOr from stdin, outputs interface by default. Outputs proxy with -p option')
   .alias('i', 'interface-file')
   .string('i')
   .describe('i', 'Specify output file for interfaces')

--- a/index.ts
+++ b/index.ts
@@ -3,9 +3,9 @@ import * as yargs from 'yargs';
 import * as fs from 'fs';
 import * as path from 'path';
 
-import {StreamWriter, NopWriter, Emitter} from './lib/index';
+import { StreamWriter, NopWriter, Emitter } from './lib/index';
 
-const argv = yargs.usage('Usage: $0 [options] inputFile rootName')
+const argv = yargs.usage('Usage: $0 [options] inputFile rootName\nFrom stdin, outputs interface by default.')
   .alias('i', 'interface-file')
   .string('i')
   .describe('i', 'Specify output file for interfaces')
@@ -16,25 +16,59 @@ const argv = yargs.usage('Usage: $0 [options] inputFile rootName')
   .alias('h', 'help')
   .argv;
 
-let interfaceWriter = new NopWriter();
-let proxyWriter = interfaceWriter;
-if (argv.i && argv.p && path.resolve(argv.i) === path.resolve(argv.p)) {
-  console.error(`Interfaces and proxies cannot be written to same file.`);
-  yargs.showHelp();
-  process.exit(1);
+if (process.stdin.isTTY) {
+  handleShellArguments();
 }
-if (argv.i) {
-  interfaceWriter = new StreamWriter(fs.createWriteStream(argv.i));
-}
-if (argv.p) {
-  proxyWriter = new StreamWriter(fs.createWriteStream(argv.p));
-}
-if (argv._.length !== 2) {
-  console.error(`Please supply an input file with samples in a JSON array, and a symbol to use for the root interface / proxy.`);
-  yargs.showHelp();
-  process.exit(1);
+else {
+  handlePipedContent();
 }
 
-const samples = JSON.parse(fs.readFileSync(argv._[0]).toString());
-const e = new Emitter(interfaceWriter, proxyWriter);
-e.emit(samples, argv._[1]);
+let interfaceWriter = new NopWriter();
+let proxyWriter = interfaceWriter;
+
+function handleShellArguments(){
+  if (argv.i && argv.p && path.resolve(argv.i) === path.resolve(argv.p)) {
+    console.error(`Interfaces and proxies cannot be written to same file.`);
+    yargs.showHelp();
+    process.exit(1);
+  }
+  if (argv.i) {
+    interfaceWriter = new StreamWriter(fs.createWriteStream(argv.i));
+  }
+  if (argv.p) {
+    proxyWriter = new StreamWriter(fs.createWriteStream(argv.p));
+  }
+  if (argv._.length !== 2) {
+    console.error(`Please supply an input file with samples in a JSON array, and a symbol to use for the root interface / proxy.`);
+    yargs.showHelp();
+    process.exit(1);
+  }
+
+  const samples = JSON.parse(fs.readFileSync(argv._[0]).toString());
+  const e = new Emitter(interfaceWriter, proxyWriter);
+  e.emit(samples, argv._[1]);
+}
+
+function handlePipedContent() {
+  let data = '';
+  process.stdin.on('readable', function() {
+    const chuck = process.stdin.read();
+    if(chuck !== null){
+      data += chuck;
+    }
+  });
+  process.stdin.on('end', function() {
+    if (!data) {
+      console.error('No input.');
+      process.exit(1);
+    }
+    if (argv.p !== undefined) {
+      proxyWriter = new StreamWriter(process.stdout);
+    } else {
+      interfaceWriter = new StreamWriter(process.stdout);
+    }
+    const samples = JSON.parse(data);
+    const e = new Emitter(interfaceWriter, proxyWriter);
+    e.emit(samples, 'root')
+  });
+}

--- a/index.ts
+++ b/index.ts
@@ -16,15 +16,15 @@ const argv = yargs.usage('Usage: $0 [options] inputFile rootName\nOr from stdin,
   .alias('h', 'help')
   .argv;
 
+let interfaceWriter = new NopWriter();
+let proxyWriter = interfaceWriter;
+
 if (process.stdin.isTTY) {
   handleShellArguments();
 }
 else {
   handlePipedContent();
 }
-
-let interfaceWriter = new NopWriter();
-let proxyWriter = interfaceWriter;
 
 function handleShellArguments(){
   if (argv.i && argv.p && path.resolve(argv.i) === path.resolve(argv.p)) {

--- a/lib/stream_writer.ts
+++ b/lib/stream_writer.ts
@@ -10,7 +10,7 @@ export default class StreamWriter extends Writer {
     this.stream = stream;
   }
   public write(s: string): this {
-    this.stream.write(new Buffer(s, 'utf8'));
+    this.stream.write(Buffer.from(s, 'utf8'));
     return this;
   }
   public close(cb: () => void): void {


### PR DESCRIPTION
Reads from stdin and, by default, outputs interface to stdout. With the option -p, outputs proxy.

"Write programs to handle text streams, because that is a universal interface."