### PR TITLE
chore(deps): bump yargs version to ^17.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
     "typescript": "^2.1.4"
   },
   "dependencies": {
-    "yargs": "^6.5.0"
+    "yargs": "^17.0.0"
   }
 }


### PR DESCRIPTION
Hi there. I'm doing security updates on a project and `yargs-parser` got flagged with a vulnerability. This PR updates `MakeTypes`'s `yargs` dependency to version from ^6.5.0 to ^17.0.0

`npm audit --omit dev` with `yargs@^6.5.0`
```
$ npm audit --omit dev
# npm audit report

yargs-parser  <=5.0.0
Severity: moderate
yargs-parser Vulnerable to Prototype Pollution - https://github.com/advisories/GHSA-p9pc-299p-vxgp
fix available via `npm audit fix --force`
Will install yargs@17.7.1, which is a breaking change
node_modules/yargs-parser
  yargs  4.0.0-alpha1 - 7.0.0-alpha.3 || 7.1.1
  Depends on vulnerable versions of yargs-parser
  node_modules/yargs

2 moderate severity vulnerabilities

To address all issues (including breaking changes), run:
  npm audit fix --force
```

`npm audit --omit dev` with `yargs@^17.0.0`
```
$ npm audit --omit dev
found 0 vulnerabilities
```

Tests are green
```
  Collections
    ✓ Empty arrays
    ✓ Numerical arrays
    ✓ Mixed type arrays

  Large Samples
    ✓ World Bank
    ✓ GitHub
    ✓ Twitter

  Primitive Types
    ✓ Number
    ✓ String
    ✓ Boolean
    ✓ Null
    ✓ Optional number
    ✓ Boolean or string

  Records
    ✓ Optional fields
    ✓ Field names with underscores


  14 passing (14ms)
```

Thanks!